### PR TITLE
Fixed mixed up firstDoses and secondDoses in fullyVaccinated section, Implemented boosterVaccinated section in scraping

### DIFF
--- a/api/_utils/scrap_data_v2.py
+++ b/api/_utils/scrap_data_v2.py
@@ -91,14 +91,14 @@ def get_data():
             },
             {
               "name": "moderna",
-              "firstDoses": row[10].value,
-              "secondDoses": row[4].value,
+              "firstDoses": row[4].value,
+              "secondDoses": row[10].value,
               "totalDoses": row[4].value + row[10].value
             },
             {
               "name": "astrazeneca",
-              "firstDoses": row[11].value,
-              "secondDoses": row[5].value,
+              "firstDoses": row[5].value,
+              "secondDoses": row[11].value,
               "totalDoses": row[5].value + row[11].value
             },
             {

--- a/api/_utils/scrap_data_v2.py
+++ b/api/_utils/scrap_data_v2.py
@@ -108,6 +108,33 @@ def get_data():
             }
           ]
         }
+        "boosterVaccinated": {
+          "doses": row[13].value,
+          "quote": round(row[13].value / total * 100, 2) if total != 0 else 0,
+          "differenceToThePreviousDay": row[17].value,
+          "vaccine": [
+            {
+              "name": "biontech",
+              "firstDoses": row[3].value,
+              "secondDoses": row[9].value,
+              "boosterDoses": row[14].value,
+              "totalDoses": row[3].value + row[9].value + row[14].value
+            },
+            {
+              "name": "moderna",
+              "firstDoses": row[4].value,
+              "secondDoses": row[10].value,
+              "boosterDoses": row[15].value,
+              "totalDoses": row[4].value + row[10].value + row[15].value
+            },
+            {
+              "name": "janssen",
+              "firstDoses": row[6].value,
+              "boosterDoses": row[16].value,
+              "totalDoses": row[6].value + row[16].value
+            }
+          ]
+        }        
       }
       rows.append(data)
   return {


### PR DESCRIPTION
It seems, that the firstDoeses and secondDoses in section fullyVaccinated for the vaccines biontech, moderna and astrazeneca were mixed up. 

Hopefully I fixed it correctly? Please revise. 